### PR TITLE
chore: project-health pipeline — mise toolchain, static-check gate, CI split, doc refresh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,25 +14,99 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  ci:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - name: Detect code changes
+        id: filter
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
+        with:
+          base: ${{ github.event_name == 'push' && 'master' || '' }}
+          filters: |
+            code:
+              - '**/*.go'
+              - 'go.mod'
+              - 'go.sum'
+              - 'Makefile'
+              - '.mise.toml'
+              - 'Dockerfile'
+              - '.goreleaser.yml'
+              - '.github/workflows/**'
+
+  static-check:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
+      - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
-
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: 'go.mod'
           cache: true
+      - name: Set up mise
+        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+        with:
+          install: true
+          cache: true
+      - name: Static check
+        run: make static-check
 
-      - name: Lint
-        run: make lint
+  build:
+    needs: [changes, static-check]
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+      - name: Build
+        run: make build
 
+  test:
+    needs: [changes, static-check]
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: 'go.mod'
+          cache: true
       - name: Test
         run: make test
 
-      - name: Build
-        run: make build
+  ci-pass:
+    if: always()
+    needs: [changes, static-check, build, test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all required jobs passed
+        run: |
+          results="${{ join(needs.*.result, ' ') }}"
+          echo "Upstream job results: $results"
+          for r in $results; do
+            if [ "$r" = "failure" ] || [ "$r" = "cancelled" ]; then
+              echo "::error::A required job did not succeed (result: $r)."
+              exit 1
+            fi
+          done
+          echo "All required jobs passed (skipped jobs are allowed)."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
 
-      - name: Login to GitHub Container Registry
+      - name: Log in to GHCR
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ghcr.io

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,12 @@
+# Pinned developer tooling for gotest.
+# `make deps` runs `mise install` to provision these; Renovate's `mise`
+# manager keeps them up to date. The Go toolchain is intentionally NOT pinned
+# here — it is single-sourced in go.mod (and CI consumes it via go-version-file)
+# to avoid a cross-file toolchain-alignment drift.
+[tools]
+node                                      = "22"
+"go:honnef.co/go/tools/cmd/staticcheck"   = "0.7.0"
+act                                       = "0.2.89"
+"go:golang.org/x/vuln/cmd/govulncheck"    = "1.3.0"
+trivy                                     = "0.71.1"
+gitleaks                                  = "8.30.1"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,13 +5,13 @@ A Go CLI playground/POC project built with Cobra, Viper, and GoReleaser.
 ## Build & Test
 
 ```bash
-make deps        # Install dependency tools (staticcheck)
-make lint        # Run staticcheck linter
-make test        # Run tests with coverage
-make build       # Build binary
-make ci          # Run lint + test + build (CI pipeline)
-make ci-run      # Run GitHub Actions workflow locally via act
-make clean       # Clean build artifacts
+make deps          # Provision pinned dev tools via mise (.mise.toml)
+make static-check  # lint + vulncheck + secrets + trivy-fs
+make test          # Run tests with coverage
+make build         # Build binary
+make ci            # static-check + test + build (CI pipeline)
+make ci-run        # Run GitHub Actions workflow locally via act
+make clean         # Clean build artifacts
 ```
 
 ## Project Structure
@@ -21,6 +21,7 @@ make clean       # Clean build artifacts
 - `internal/cmd/` - Cobra CLI root command and configuration
 - `internal/calc/` - Math utilities with tests
 - `hack/` - Release and tag management scripts
+- `.mise.toml` - Pinned dev tooling (staticcheck, govulncheck, Trivy, gitleaks, act, node)
 - `Dockerfile` - Alpine-based container image (built via goreleaser)
 
 ## Key Details
@@ -30,7 +31,8 @@ make clean       # Clean build artifacts
 - **Default branch**: `master`
 - **CI triggers on**: `master` branch (push/PR) and `v*` tags
 - **Release**: Tag-triggered via GoReleaser (`v*` tags)
-- **Linter**: `staticcheck` (installed via `make deps`, version pinned in Makefile)
+- **Tooling**: provisioned by [mise](https://mise.jdx.dev/) (`.mise.toml`); the Go toolchain stays single-sourced in `go.mod`
+- **Static analysis**: `make static-check` = staticcheck + govulncheck + Trivy (fs) + gitleaks
 - **Test coverage**: `go test ./... -cover`
 
 ## CI/CD
@@ -39,7 +41,7 @@ GitHub Actions workflows in `.github/workflows/`:
 
 | Workflow | File | Triggers | Steps |
 |----------|------|----------|-------|
-| CI | `ci.yml` | push to master, PRs, `v*` tags | Lint, Test, Build (via `make` targets) |
+| CI | `ci.yml` | push to master, PRs, `v*` tags | `changes` → `static-check`, `build`, `test` → `ci-pass` (via `make` targets) |
 | Release | `release.yml` | `v*` tags | GoReleaser build + GitHub release + GHCR push |
 | Cleanup | `cleanup-runs.yml` | weekly (Sunday) + manual | Delete old workflow runs (retain 7 days, min 5) |
 
@@ -52,6 +54,6 @@ Use the following skills when working on related files:
 | `Makefile` | `/makefile` |
 | `renovate.json` | `/renovate` |
 | `README.md` | `/readme` |
-| `.github/workflows/*.yml` | `/ci-workflow` |
+| `.github/workflows/*.{yml,yaml}` | `/ci-workflow` |
 
 When spawning subagents, always pass conventions from the respective skill into the agent's prompt.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,9 @@
 .DEFAULT_GOAL := help
+SHELL := /bin/bash
+
+# mise provisions pinned dev tools (see .mise.toml). Put its shim dir and the
+# user-local bin dir on PATH so recipes resolve the tools deps just installed.
+export PATH := $(HOME)/.local/share/mise/shims:$(HOME)/.local/bin:$(PATH)
 
 APP_NAME       := gotest
 CURRENTTAG     := $(shell git describe --tags --abbrev=0 2>/dev/null || echo "dev")
@@ -7,14 +12,9 @@ commitSHA=$(shell git describe --dirty --always)
 dateStr=$(shell date +%s)
 DATE := $(shell /bin/date +%m-%d-%Y)
 
-VERSION := $(shell cat ./main.go | grep "const Version ="| cut -d"\"" -f2)
+VERSION := $(shell grep 'const Version =' main.go | cut -d'"' -f2)
 
 SEMVER_RE := ^v[0-9]+\.[0-9]+\.[0-9]+$$
-
-# === Tool Versions (pinned) ===
-STATICCHECK_VERSION := 0.6.0
-ACT_VERSION         := 0.2.87
-NVM_VERSION         := 0.40.4
 
 #help: @ List available tasks
 help:
@@ -22,25 +22,35 @@ help:
 	@echo "Commands :"
 	@grep -E '[a-zA-Z\.\-]+:.*?@ .*$$' $(MAKEFILE_LIST)| tr -d '#' | awk 'BEGIN {FS = ":.*?@ "}; {printf "\033[32m%-30s\033[0m - %s\n", $$1, $$2}'
 
-#deps: @ Install dependency tools (idempotent)
+#deps: @ Install pinned dev tools via mise (idempotent)
 deps:
-	@command -v staticcheck >/dev/null 2>&1 || go install honnef.co/go/tools/cmd/staticcheck@v$(STATICCHECK_VERSION)
-
-#deps-act: @ Install act for local CI (idempotent)
-deps-act: deps
-	@command -v act >/dev/null 2>&1 || { echo "Installing act $(ACT_VERSION)..."; \
-		curl -sSfL https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo bash -s -- -b /usr/local/bin v$(ACT_VERSION); \
-	}
+	@command -v mise >/dev/null 2>&1 || { echo "mise not found — install from https://mise.run"; exit 1; }
+	@mise install
 
 #all: @ Build all
 all: build
 
-#lint: @ Run linter
+#lint: @ Run staticcheck linter
 lint: deps
 	@staticcheck ./...
 
+#vulncheck: @ Scan for known Go vulnerabilities (govulncheck)
+vulncheck: deps
+	@govulncheck ./...
+
+#trivy-fs: @ Scan filesystem dependencies and secrets for CVEs (Trivy)
+trivy-fs: deps
+	@trivy fs --scanners vuln,secret --severity HIGH,CRITICAL --exit-code 1 --no-progress .
+
+#secrets: @ Scan the working tree for leaked secrets (gitleaks)
+secrets: deps
+	@gitleaks dir . --no-banner
+
+#static-check: @ Run all static analysis (lint + vulncheck + secrets + trivy-fs)
+static-check: lint vulncheck secrets trivy-fs
+
 #test: @ Run tests with coverage
-test: deps
+test:
 	@mkdir -p ./.bin/
 	@go test -v ./... -cover -coverprofile=./.bin/coverage.out
 
@@ -66,15 +76,9 @@ ifneq (,$(wildcard /usr/local/bin/gotest))
 	@sudo rm /usr/local/bin/gotest
 endif
 
-CNT := $(shell which -a gotest | wc -l)
-EXCODE := $(shell which -a gotest | wc -l >/dev/null; echo $$?)
-RES := $(shell test $(CNT) -gt 0 && echo $$?)
-
 #show: @ Show gotest binary locations
 show:
-ifeq ($(RES), 0)
-	@which -a gotest
-endif
+	@which -a gotest || true
 
 #run: @ Build and run gotest
 run: build
@@ -110,7 +114,7 @@ release: clean
 
 #update: @ Update dependency packages to latest versions
 update:
-	@export GOPRIVATE=$(GOPRIVATE); go get -u; go mod tidy
+	@go get -u; go mod tidy
 
 #version: @ Print current version(tag)
 version:
@@ -138,29 +142,20 @@ release-test-local: build
 	@goreleaser check
 	@goreleaser release --clean --snapshot
 
-#ci: @ Run lint, tests, and build (CI pipeline)
-ci: lint test build
+#ci: @ Run static analysis, tests, and build (CI pipeline)
+ci: static-check test build
 
 #ci-run: @ Run GitHub Actions workflow locally using act
-ci-run: deps-act
+ci-run: deps
 	@act push --container-architecture linux/amd64 \
 		--artifact-server-path /tmp/act-artifacts
 
-#renovate-bootstrap: @ Install nvm and npm for Renovate
-renovate-bootstrap:
-	@command -v node >/dev/null 2>&1 || { \
-		echo "Installing nvm $(NVM_VERSION)..."; \
-		curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v$(NVM_VERSION)/install.sh | bash; \
-		export NVM_DIR="$$HOME/.nvm"; \
-		[ -s "$$NVM_DIR/nvm.sh" ] && . "$$NVM_DIR/nvm.sh"; \
-		nvm install --lts; \
-	}
-
 #renovate-validate: @ Validate Renovate configuration
-renovate-validate: renovate-bootstrap
+renovate-validate: deps
 	@npx --yes renovate --platform=local
 
-.PHONY: help deps deps-act all lint test test-coverage-view build clean clean-all \
-	show run image-build changelog-generate tag tags-push release update version \
+.PHONY: help deps all lint vulncheck trivy-fs secrets static-check test \
+	test-coverage-view build clean clean-all show run image-build \
+	changelog-generate tag tags-push release update version \
 	tags-delete-local tags-delete-remote tags-delete-all tags-delete-current \
-	release-test-local ci ci-run renovate-bootstrap renovate-validate
+	release-test-local ci ci-run renovate-validate

--- a/README.md
+++ b/README.md
@@ -3,14 +3,33 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-brightgreen.svg)](https://opensource.org/licenses/MIT)
 [![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://app.renovatebot.com/dashboard#github/AndriyKalashnykov/gotest)
 
-# gotest
+# gotest — Go CLI Playground
 
-A Go CLI playground and proof-of-concept project built with Cobra, Viper, and GoReleaser. Demonstrates struct parsing, CLI commands, and release automation.
+A Go CLI playground and proof-of-concept built with **Cobra** (commands), **Viper** (config),
+and **GoReleaser** (release automation). It demonstrates reflection-based struct-tag parsing and
+serves as a reference for the project tooling used across the portfolio: a **mise**-provisioned
+dev toolchain, a `static-check` quality gate (staticcheck + govulncheck + Trivy + gitleaks),
+**GitHub Actions** CI, **GoReleaser**-published binaries and a **GHCR** Docker image, and
+**Renovate** dependency automation.
+
+## Tech Stack
+
+| Component | Technology |
+|-----------|------------|
+| Language | Go 1.25 (see `go.mod`) |
+| CLI framework | [Cobra](https://github.com/spf13/cobra) |
+| Configuration | [Viper](https://github.com/spf13/viper) |
+| Release automation | [GoReleaser](https://goreleaser.com/) |
+| Container image | Docker (Alpine), published to GHCR |
+| CI/CD | GitHub Actions |
+| Static analysis | staticcheck, govulncheck, Trivy, gitleaks |
+| Tool versioning | [mise](https://mise.jdx.dev/) |
+| Dependency updates | [Renovate](https://docs.renovatebot.com/) |
 
 ## Quick Start
 
 ```bash
-make deps      # install tools (staticcheck)
+make deps      # provision pinned dev tools via mise
 make build     # build the binary
 make test      # run tests with coverage
 make run       # build and run gotest
@@ -20,64 +39,16 @@ make run       # build and run gotest
 
 | Tool | Version | Purpose |
 |------|---------|---------|
-| [GNU Make](https://www.gnu.org/software/make/) | 3.81+ | Build orchestration |
+| [mise](https://mise.jdx.dev/) | latest | Provisions pinned dev tools (staticcheck, govulncheck, Trivy, gitleaks, act, node) |
 | [Go](https://go.dev/dl/) | 1.25+ | Go toolchain (see `go.mod`) |
+| [GNU Make](https://www.gnu.org/software/make/) | 3.81+ | Build orchestration |
 | [Docker](https://www.docker.com/) | latest | Container image builds (optional) |
 
-Install all required dependencies:
+Install [mise](https://mise.jdx.dev/getting-started.html), then provision the dev tools:
 
 ```bash
 make deps
 ```
-
-## Available Make Targets
-
-Run `make help` to see all available targets.
-
-### Build & Run
-
-| Target | Description |
-|--------|-------------|
-| `make build` | Build binary |
-| `make clean` | Clean build artifacts |
-| `make clean-all` | Clean all build artifacts including system-wide installs |
-| `make run` | Build and run gotest |
-| `make image-build` | Build Docker image |
-
-### Code Quality
-
-| Target | Description |
-|--------|-------------|
-| `make lint` | Run linter |
-| `make test` | Run tests with coverage |
-| `make test-coverage-view` | Run tests and open coverage report in browser |
-
-### CI
-
-| Target | Description |
-|--------|-------------|
-| `make ci` | Run lint, tests, and build (CI pipeline) |
-| `make ci-run` | Run GitHub Actions workflow locally using [act](https://github.com/nektos/act) |
-
-### Release
-
-| Target | Description |
-|--------|-------------|
-| `make version` | Print current version(tag) |
-| `make release` | Create and push a release (validates semver) |
-| `make release-test-local` | Build binaries locally without publishing |
-| `make tag` | Create a release tag |
-| `make tags-push` | Push all tags to remote |
-| `make changelog-generate` | Generate changelog |
-
-### Utilities
-
-| Target | Description |
-|--------|-------------|
-| `make deps` | Install dependency tools (idempotent) |
-| `make update` | Update dependency packages to latest versions |
-| `make show` | Show gotest binary locations |
-| `make renovate-validate` | Validate Renovate configuration |
 
 ## Installation
 
@@ -91,19 +62,99 @@ Download and install a binary locally:
 ./hack/get-gotest.sh
 ```
 
+### Docker
+
+A container image is published to the GitHub Container Registry on each `v*` tag:
+
+```bash
+docker pull ghcr.io/andriykalashnykov/gotest:latest
+docker run --rm ghcr.io/andriykalashnykov/gotest:latest --help
+```
+
 ### From source
 
 ```bash
 go install github.com/AndriyKalashnykov/gotest@latest
 ```
 
+## Available Make Targets
+
+Run `make help` to see all available targets.
+
+### Build & Run
+
+| Target | Description |
+|--------|-------------|
+| `make all` | Build all (alias for `build`) |
+| `make build` | Build binary |
+| `make clean` | Clean build artifacts |
+| `make clean-all` | Clean all build artifacts including system-wide installs |
+| `make run` | Build and run gotest |
+| `make image-build` | Build Docker image |
+| `make show` | Show gotest binary locations |
+
+### Code Quality
+
+| Target | Description |
+|--------|-------------|
+| `make static-check` | Run all static analysis (lint + vulncheck + secrets + trivy-fs) |
+| `make lint` | Run staticcheck linter |
+| `make vulncheck` | Scan for known Go vulnerabilities (govulncheck) |
+| `make trivy-fs` | Scan filesystem dependencies and secrets for CVEs (Trivy) |
+| `make secrets` | Scan the working tree for leaked secrets (gitleaks) |
+| `make test` | Run tests with coverage |
+| `make test-coverage-view` | Run tests and open coverage report in browser |
+
+### CI
+
+| Target | Description |
+|--------|-------------|
+| `make ci` | Run static analysis, tests, and build (CI pipeline) |
+| `make ci-run` | Run GitHub Actions workflow locally using [act](https://github.com/nektos/act) |
+
+### Release
+
+| Target | Description |
+|--------|-------------|
+| `make version` | Print current version (tag) |
+| `make release` | Create and push a release (validates semver) |
+| `make release-test-local` | Build binaries locally without publishing |
+| `make tag` | Create a release tag |
+| `make tags-push` | Push all tags to remote |
+| `make changelog-generate` | Generate changelog |
+| `make tags-delete-local` | Delete all local tags |
+| `make tags-delete-remote` | Delete all remote tags |
+| `make tags-delete-all` | Delete all local and remote tags |
+| `make tags-delete-current` | Delete the current version tag locally and remotely |
+
+### Utilities
+
+| Target | Description |
+|--------|-------------|
+| `make deps` | Provision pinned dev tools via mise (idempotent) |
+| `make update` | Update dependency packages to latest versions |
+| `make renovate-validate` | Validate Renovate configuration |
+
 ## CI/CD
 
-GitHub Actions runs on every push to `master`, tags `v*`, and pull requests.
+GitHub Actions runs on every push to `master`, on `v*` tags, and on pull requests.
 
-| Job | Triggers | Steps |
-|-----|----------|-------|
-| **ci** | push to master, PRs, tags | Lint, Test, Build |
-| **goreleaser** | tag `v*` | Build binaries, Docker image, GitHub release |
+| Workflow | Triggers | Jobs |
+|----------|----------|------|
+| **CI** (`ci.yml`) | push to master, PRs, `v*` tags | `changes` (path filter) → `static-check`, `build`, `test` → `ci-pass` |
+| **Release** (`release.yml`) | `v*` tags | `goreleaser`: build binaries, Docker image (GHCR), GitHub release |
+| **Cleanup** (`cleanup-runs.yml`) | weekly (Sunday) + manual | Delete old workflow runs (retain 7 days, keep min 5) |
 
-[Renovate](https://docs.renovatebot.com/) keeps dependencies up to date with platform automerge enabled.
+`ci-pass` aggregates the CI jobs into a single status check — set it as the required status check
+in branch protection so a failing build cannot merge.
+
+### Required Secrets and Variables
+
+| Name | Type | Used by | Purpose |
+|------|------|---------|---------|
+| `GH_ACCESS_TOKEN` | Secret | `release` (`goreleaser`) | GitHub PAT with `write:packages` for pushing the image to GHCR (`ghcr.io/andriykalashnykov/gotest`, a user-namespace package). `GITHUB_TOKEN` alone cannot create user-namespace packages. |
+
+`GITHUB_TOKEN` is provided automatically by GitHub Actions and needs no configuration.
+
+[Renovate](https://docs.renovatebot.com/) keeps dependencies up to date, with automerge enabled
+on green CI.

--- a/renovate.json
+++ b/renovate.json
@@ -11,11 +11,17 @@
   "labels": [
     "dependencies"
   ],
+  "enabledManagers": [
+    "gomod",
+    "github-actions",
+    "dockerfile",
+    "mise"
+  ],
   "prConcurrentLimit": 50,
   "prHourlyLimit": 0,
-  "platformAutomerge": true,
+  "platformAutomerge": false,
   "automerge": true,
-  "automergeType": "branch",
+  "automergeType": "pr",
   "automergeStrategy": "squash",
   "ignoreTests": false,
   "postUpdateOptions": [
@@ -63,20 +69,21 @@
       "commitMessagePrefix": "chore(go): "
     },
     {
-      "description": "Group Docker images",
+      "description": "Group Docker base images",
       "matchManagers": [
-        "dockerfile",
-        "docker-compose"
+        "dockerfile"
       ],
       "groupName": "docker",
       "commitMessagePrefix": "chore(docker): "
     },
     {
-      "description": "Group Docker base images",
-      "matchDatasources": [
-        "docker"
+      "description": "Group mise-managed dev tools and hold each new version for 3 days so the upstream GitHub Release artifacts that mise's aqua:/go: backends install are published before the PR opens (prevents the tag-before-publish 404 on mise install)",
+      "matchManagers": [
+        "mise"
       ],
-      "groupName": "Docker dependencies"
+      "groupName": "dev-tools",
+      "commitMessagePrefix": "chore(tools): ",
+      "minimumReleaseAge": "3 days"
     }
   ]
 }


### PR DESCRIPTION
Full `/project-review` → `/renovate` → `/readme` → `/ship-it` pass.

## Foundation (Phase A)
- **`.mise.toml`** (new) — pins node, staticcheck, act, govulncheck, trivy, gitleaks. Replaces nvm in `renovate-bootstrap`; Go stays single-sourced in `go.mod` (no toolchain-alignment duplication).
- **Makefile** — `deps` via `mise install` (drops sudo + nvm + `--lts`); new `vulncheck` (govulncheck), `trivy-fs`, `secrets` (gitleaks) and a `static-check` composite gate; `ci = static-check test build`; `SHELL`/`PATH`; robust `VERSION`; simplified `show`/`update`.
- **renovate.json** — gated automerge (`automergeType: pr`, `platformAutomerge: false` to dodge the check-registration race), `enabledManagers` incl. `mise`, collapsed the two overlapping Docker rules, grouped mise tools with a 3-day release-age buffer (tag-before-publish guard).
- **ci.yml** — split the single `ci` job into `changes` (paths-filter) → `static-check`/`build`/`test` → `ci-pass` aggregator; `static-check` gets `jdx/mise-action`; canonical step names.
- **release.yml** — `Log in to GHCR`.

## Docs (Phase B)
- **README** — Tech Stack table, all 30 make targets, Required Secrets table (`GH_ACCESS_TOKEN`), mise prerequisite, GHCR Docker install, richer description, corrected section order (Installation before Make Targets).
- **CLAUDE.md** — mise/`static-check`/`.mise.toml`, split-CI table, workflow glob `*.{yml,yaml}`.

## Also applied out-of-band
- Branch protection on `master` now requires the **`ci-pass`** check (no required reviews, so Renovate automerge still works).
- GitHub About set to a real one-liner.
- act `0.2.87 → 0.2.89`.

## Deferred (report-only)
Docker image hardening (root user, no image scan/cosign/SBOM/provenance, single-arch) — run `/ship-it harden` / `/harden-image-pipeline` as a follow-up. DAST/HEALTHCHECK are N/A (CLI).

## Test plan
- `make ci` (static-check + test + build) passes locally; calc tests 100%.
- renovate config validates; `mise` manager extracts 6 tools.
- actionlint clean on ci.yml + release.yml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)