### PR TITLE
chore(go): Go 1.26.4 toolchain with mise-aligned build + drift guard

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,9 +1,14 @@
 # Pinned developer tooling for gotest.
 # `make deps` runs `mise install` to provision these; Renovate's `mise`
-# manager keeps them up to date. The Go toolchain is intentionally NOT pinned
-# here — it is single-sourced in go.mod (and CI consumes it via go-version-file)
-# to avoid a cross-file toolchain-alignment drift.
+# manager keeps them up to date.
+#
+# `go` is pinned here AND in go.mod: mise's `go:` backend builds staticcheck /
+# govulncheck from source, so it must use the SAME Go the project targets
+# (otherwise the binaries are built with the wrong toolchain and fail to analyse
+# newer-Go code). `make check-toolchain-alignment` enforces go.mod == .mise.toml,
+# and a Renovate cross-manager group bumps both together.
 [tools]
+go                                        = "1.26.4"
 node                                      = "24"
 "go:honnef.co/go/tools/cmd/staticcheck"   = "0.7.0"
 act                                       = "0.2.89"

--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,17 @@ trivy-fs: deps
 secrets: deps
 	@gitleaks dir . --no-banner
 
-#static-check: @ Run all static analysis (lint + vulncheck + secrets + trivy-fs)
-static-check: lint vulncheck secrets trivy-fs
+#check-toolchain-alignment: @ Verify the Go version matches across go.mod and .mise.toml
+check-toolchain-alignment:
+	@gomod=$$(grep -oE '^go [0-9.]+' go.mod | awk '{print $$2}'); \
+	mise=$$(grep -oE '^go[[:space:]]*=[[:space:]]*"[0-9.]+"' .mise.toml | grep -oE '[0-9.]+'); \
+	if [ "$$gomod" != "$$mise" ]; then \
+		echo "ERROR: Go version mismatch — go.mod=$$gomod .mise.toml=$$mise (bump both together)"; \
+		exit 1; \
+	fi
+
+#static-check: @ Run all static analysis (alignment + lint + vulncheck + secrets + trivy-fs)
+static-check: check-toolchain-alignment lint vulncheck secrets trivy-fs
 
 #test: @ Run tests with coverage
 test:
@@ -154,7 +163,7 @@ ci-run: deps
 renovate-validate: deps
 	@npx --yes renovate --platform=local
 
-.PHONY: help deps all lint vulncheck trivy-fs secrets static-check test \
+.PHONY: help deps all lint vulncheck trivy-fs secrets check-toolchain-alignment static-check test \
 	test-coverage-view build clean clean-all show run image-build \
 	changelog-generate tag tags-push release update version \
 	tags-delete-local tags-delete-remote tags-delete-all tags-delete-current \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/AndriyKalashnykov/gotest
 
-go 1.25.11
+go 1.26.4
 
 require (
 	github.com/mitchellh/go-homedir v1.1.0

--- a/internal/calc/math_test.go
+++ b/internal/calc/math_test.go
@@ -8,7 +8,7 @@ func TestAdd(t *testing.T) {
 	want := 10
 
 	if got != want {
-		t.Errorf("got %q, wanted %q", got, want)
+		t.Errorf("got %d, wanted %d", got, want)
 	}
 }
 
@@ -17,7 +17,7 @@ func TestSubtract(t *testing.T) {
 	want := -2
 
 	if got != want {
-		t.Errorf("got %q, wanted %q", got, want)
+		t.Errorf("got %d, wanted %d", got, want)
 	}
 }
 

--- a/renovate.json
+++ b/renovate.json
@@ -84,6 +84,19 @@
       "groupName": "dev-tools",
       "commitMessagePrefix": "chore(tools): ",
       "minimumReleaseAge": "3 days"
+    },
+    {
+      "description": "Group the Go toolchain (go.mod directive + .mise.toml go pin) into one PR so both bump together — mise builds staticcheck/govulncheck with this Go, so it must match go.mod (enforced by `make check-toolchain-alignment`)",
+      "matchManagers": [
+        "gomod",
+        "mise"
+      ],
+      "matchDepNames": [
+        "go",
+        "golang"
+      ],
+      "groupName": "Go toolchain",
+      "commitMessagePrefix": "chore(go): "
     }
   ]
 }


### PR DESCRIPTION
Properly delivers the Go 1.26.4 bump that Renovate **#128** attempted. #128 (bare `go.mod` `1.25.11 → 1.26.4`) failed CI because mise's `go:` backend built `staticcheck`/`govulncheck` with **Go 1.25** on the runner — there was no project-pinned Go in `.mise.toml` — so staticcheck couldn't analyse 1.26 code:

```
package requires newer Go version go1.26 (application built with go1.25) (compile)
```

## Fix
- **`.mise.toml`** — pin `go = "1.26.4"` so mise builds the go-backend tools with the project's Go.
- **`go.mod`** — `go 1.25.11 → 1.26.4`.
- **Makefile** — `check-toolchain-alignment` (go.mod == .mise.toml), first prereq of `static-check` (negative-tested: goes RED on mismatch).
- **renovate.json** — cross-manager **Go toolchain** group (`gomod` + `mise`, `go`/`golang`) so both pins bump together (prevents the split-PR deadlock).
- **`internal/calc/math_test.go`** — `%q → %d` for int args; a latent printf bug the stricter Go 1.26 `go vet` surfaced.

## Fact-check
- Go 1.26.4 is the current stable (matches the locally-installed toolchain).
- staticcheck v0.7.0 (= release 2026.1) supports Go 1.26; built with Go 1.26.4 it lints the code clean.

## Test plan
- `make ci` (static-check + test + build) passes locally on Go 1.26.4.
- Alignment guard passes aligned, fails on mismatch.
- renovate config validates.

Closes #128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)