### PR TITLE
refactor: extract struct-tag demo into internal/structtag, clean up CLI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,10 +16,11 @@ make clean         # Clean build artifacts
 
 ## Project Structure
 
-- `main.go` - Entry point, struct parsing examples, version constant
-- `version.go` - CLI version command using go-version
-- `internal/cmd/` - Cobra CLI root command and configuration
-- `internal/calc/` - Math utilities with tests
+- `main.go` - Entry point and release version constant (grepped by `make release`)
+- `version.go` - `version` subcommand (go-version; build info injected via ldflags)
+- `internal/cmd/` - Cobra commands (`root`, `fields`) and Viper config
+- `internal/structtag/` - Reflection-based struct-tag field grouping (the core demo)
+- `internal/calc/` - Integer math helpers with table-driven tests
 - `hack/` - Release and tag management scripts
 - `.mise.toml` - Pinned dev tooling (staticcheck, govulncheck, Trivy, gitleaks, act, node)
 - `Dockerfile` - Alpine-based container image (built via goreleaser)

--- a/README.md
+++ b/README.md
@@ -50,6 +50,24 @@ Install [mise](https://mise.jdx.dev/getting-started.html), then provision the de
 make deps
 ```
 
+## Usage
+
+```bash
+# Print build information (version, commit, date) as JSON or YAML
+gotest version
+gotest version --short
+gotest version --output yaml
+
+# Demonstrate reflection-based struct-tag parsing: group a sample struct's
+# fields by a struct tag (default "validate") and print the result as JSON
+gotest fields
+gotest fields --tag validate
+```
+
+`gotest fields` reflects over a sample `Account` struct and groups its fields by
+tag value (`required`, `optional`, `optional,association`) — the core
+proof-of-concept this playground exists to demonstrate.
+
 ## Installation
 
 ### Binaries

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
-	github.com/worldline-go/struct2 v1.4.0
 	go.hein.dev/go-version v0.1.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -123,8 +123,6 @@ github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSW
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
-github.com/worldline-go/struct2 v1.4.0 h1:81QtMoOyux9aVXjPeqaDPJQVb3y/akSWm0AjNjK7U2w=
-github.com/worldline-go/struct2 v1.4.0/go.mod h1:WQ0q9deNrhnzWkWvrC1sIYc6SfziRsRCAwQBgS94T8E=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=

--- a/internal/calc/math.go
+++ b/internal/calc/math.go
@@ -1,17 +1,26 @@
+// Package calc provides small integer arithmetic helpers. It exists mainly to
+// demonstrate table-driven testing in this playground.
 package calc
 
-import "fmt"
+import "errors"
 
-// Add is our function that sums two integers
-func Add(x, y int) (res int) {
-	return x + y
-}
+// ErrDivideByZero is returned by Divide when the divisor is zero.
+var ErrDivideByZero = errors.New("calc: division by zero")
 
-// Subtract subtracts two integers
-func Subtract(x, y int) (res int) {
-	return x - y
-}
+// Add returns the sum of x and y.
+func Add(x, y int) int { return x + y }
 
-func test() {
-	fmt.Println("test")
+// Subtract returns the difference x - y.
+func Subtract(x, y int) int { return x - y }
+
+// Multiply returns the product of x and y.
+func Multiply(x, y int) int { return x * y }
+
+// Divide returns the integer quotient x / y. It returns ErrDivideByZero when y
+// is zero. Division truncates toward zero, matching Go's `/` operator.
+func Divide(x, y int) (int, error) {
+	if y == 0 {
+		return 0, ErrDivideByZero
+	}
+	return x / y, nil
 }

--- a/internal/calc/math_test.go
+++ b/internal/calc/math_test.go
@@ -1,26 +1,91 @@
 package calc
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
 
 func TestAdd(t *testing.T) {
-
-	got := Add(4, 6)
-	want := 10
-
-	if got != want {
-		t.Errorf("got %d, wanted %d", got, want)
+	tests := []struct {
+		name string
+		x, y int
+		want int
+	}{
+		{"positives", 4, 6, 10},
+		{"with negative", -4, 6, 2},
+		{"both negative", -4, -6, -10},
+		{"zeros", 0, 0, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Add(tt.x, tt.y); got != tt.want {
+				t.Errorf("Add(%d, %d) = %d, want %d", tt.x, tt.y, got, tt.want)
+			}
+		})
 	}
 }
 
 func TestSubtract(t *testing.T) {
-	got := Subtract(4, 6)
-	want := -2
-
-	if got != want {
-		t.Errorf("got %d, wanted %d", got, want)
+	tests := []struct {
+		name string
+		x, y int
+		want int
+	}{
+		{"positive result", 6, 4, 2},
+		{"negative result", 4, 6, -2},
+		{"identity", 5, 0, 5},
+		{"to zero", 7, 7, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Subtract(tt.x, tt.y); got != tt.want {
+				t.Errorf("Subtract(%d, %d) = %d, want %d", tt.x, tt.y, got, tt.want)
+			}
+		})
 	}
 }
 
-func TestTest(t *testing.T) {
-	test()
+func TestMultiply(t *testing.T) {
+	tests := []struct {
+		name string
+		x, y int
+		want int
+	}{
+		{"positives", 4, 6, 24},
+		{"by zero", 5, 0, 0},
+		{"sign flip", -4, 6, -24},
+		{"two negatives", -4, -6, 24},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Multiply(tt.x, tt.y); got != tt.want {
+				t.Errorf("Multiply(%d, %d) = %d, want %d", tt.x, tt.y, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDivide(t *testing.T) {
+	tests := []struct {
+		name    string
+		x, y    int
+		want    int
+		wantErr error
+	}{
+		{"exact", 6, 2, 3, nil},
+		{"truncates toward zero", 7, 2, 3, nil},
+		{"negative dividend truncates toward zero", -7, 2, -3, nil},
+		{"by zero", 1, 0, 0, ErrDivideByZero},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Divide(tt.x, tt.y)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("Divide(%d, %d) error = %v, want %v", tt.x, tt.y, err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("Divide(%d, %d) = %d, want %d", tt.x, tt.y, got, tt.want)
+			}
+		})
+	}
 }

--- a/internal/cmd/fields.go
+++ b/internal/cmd/fields.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/AndriyKalashnykov/gotest/internal/structtag"
+	"github.com/spf13/cobra"
+)
+
+// Transaction and Account are sample structs used to demonstrate
+// reflection-based struct-tag grouping. Their fields are read via reflection
+// (by struct.tag), not directly, so they are exported to document the example.
+type Transaction struct {
+	Name *string `validate:"required"`
+}
+
+// Account is the sample struct the `fields` command inspects.
+type Account struct {
+	Address          *string       `validate:"required"`
+	NetworkID        *uint         `validate:"required"`
+	NodeID           *uint         `validate:"optional"`
+	PoolID           *uint         `validate:"optional"`
+	ToTransactions   []Transaction `validate:"optional,association"`
+	FromTransactions []Transaction `validate:"optional,association"`
+}
+
+var fieldsTag string
+
+var fieldsCmd = &cobra.Command{
+	Use:   "fields",
+	Short: "Group a sample struct's fields by a struct tag",
+	Long: "fields demonstrates reflection-based struct-tag parsing: it groups the\n" +
+		"fields of a sample Account struct by the value of the chosen tag\n" +
+		"(default \"validate\") and prints the result as JSON.",
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		groups, err := structtag.GroupFieldsByTag(Account{}, fieldsTag)
+		if err != nil {
+			return err
+		}
+		out, err := json.MarshalIndent(groups, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), string(out))
+		return nil
+	},
+}
+
+func init() {
+	fieldsCmd.Flags().StringVarP(&fieldsTag, "tag", "t", "validate", "struct tag to group fields by")
+	RootCmd.AddCommand(fieldsCmd)
+}

--- a/internal/cmd/fields_test.go
+++ b/internal/cmd/fields_test.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func runFields(t *testing.T, args ...string) string {
+	t.Helper()
+	var out bytes.Buffer
+	RootCmd.SetOut(&out)
+	RootCmd.SetErr(&out)
+	RootCmd.SetArgs(append([]string{"fields"}, args...))
+	if err := RootCmd.Execute(); err != nil {
+		t.Fatalf("fields command failed: %v", err)
+	}
+	return out.String()
+}
+
+func TestFieldsCommand_DefaultTag(t *testing.T) {
+	got := runFields(t)
+
+	var groups map[string][]string
+	if err := json.Unmarshal([]byte(got), &groups); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, got)
+	}
+
+	want := map[string][]string{
+		"required":             {"Address", "NetworkID"},
+		"optional":             {"NodeID", "PoolID"},
+		"optional,association": {"ToTransactions", "FromTransactions"},
+	}
+	if !reflect.DeepEqual(groups, want) {
+		t.Errorf("groups = %v, want %v", groups, want)
+	}
+}
+
+func TestFieldsCommand_UnknownTagIsEmpty(t *testing.T) {
+	got := runFields(t, "--tag", "json")
+
+	var groups map[string][]string
+	if err := json.Unmarshal([]byte(got), &groups); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, got)
+	}
+	if len(groups) != 0 {
+		t.Errorf("groups = %v, want empty for an unused tag", groups)
+	}
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -4,26 +4,23 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/spf13/cobra"
-
 	homedir "github.com/mitchellh/go-homedir"
+	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
+const configName = ".gotest"
+
 var cfgFile string
 
-// RootCmd represents the base command when called without any subcommands
+// RootCmd is the base command, invoked when gotest is run without a subcommand.
 var RootCmd = &cobra.Command{
 	Use:   "gotest",
-	Short: "gotest - a Golang POC",
-	Long:  "gotest - a Golang POC playground",
-	// Uncomment the following line if your bare application
-	// has an action associated with it:
-	//	Run: func(cmd *cobra.Command, args []string) { },
+	Short: "gotest - a Go CLI playground",
+	Long:  "gotest is a small Cobra-based CLI playground and proof-of-concept.",
 }
 
-// Execute adds all child commands to the root command and sets flags appropriately.
-// This is called by main.main(). It only needs to happen once to the RootCmd.
+// Execute runs the root command tree. It is called once by main.main().
 func Execute() {
 	if err := RootCmd.Execute(); err != nil {
 		fmt.Println(err)
@@ -33,39 +30,26 @@ func Execute() {
 
 func init() {
 	cobra.OnInitialize(initConfig)
-
-	// Here you will define your flags and configuration settings.
-	// Cobra supports persistent flags, which, if defined here,
-	// will be global for your application.
-
-	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.example.yaml)")
-
-	// Cobra also supports local flags, which will only run
-	// when this action is called directly.
-	RootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "",
+		fmt.Sprintf("config file (default is $HOME/%s.yaml)", configName))
 }
 
-// initConfig reads in config file and ENV variables if set.
+// initConfig reads the config file (if any) and environment variables.
 func initConfig() {
 	if cfgFile != "" {
-		// Use config file from the flag.
 		viper.SetConfigFile(cfgFile)
 	} else {
-		// Find home directory.
 		home, err := homedir.Dir()
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)
 		}
-
-		// Search config in home directory with name ".example" (without extension).
 		viper.AddConfigPath(home)
-		viper.SetConfigName(".example")
+		viper.SetConfigName(configName)
 	}
 
 	viper.AutomaticEnv() // read in environment variables that match
 
-	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {
 		fmt.Println("Using config file:", viper.ConfigFileUsed())
 	}

--- a/internal/structtag/structtag.go
+++ b/internal/structtag/structtag.go
@@ -1,0 +1,51 @@
+// Package structtag groups a struct's exported field names by the value of a
+// chosen struct tag, using reflection.
+//
+// It is the core demonstration of this playground: given a struct annotated
+// with, for example, `validate:"required"`, GroupFieldsByTag reports which
+// fields fall under each distinct tag value.
+package structtag
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// GroupFieldsByTag walks v — a struct or a (possibly nested) pointer to a
+// struct — and groups the names of its exported fields by the value of the
+// struct tag named tag.
+//
+// Fields without the tag, and fields whose tag value is "-", are skipped. The
+// returned map's keys are the distinct tag values; each slice preserves the
+// struct's field-declaration order. Only top-level fields are considered;
+// nested structs are not descended into.
+//
+// An error is returned if v is nil, is a nil pointer, or does not resolve to a
+// struct.
+func GroupFieldsByTag(v any, tag string) (map[string][]string, error) {
+	rv := reflect.ValueOf(v)
+	for rv.Kind() == reflect.Pointer {
+		if rv.IsNil() {
+			return nil, fmt.Errorf("structtag: nil pointer to %s", rv.Type().Elem())
+		}
+		rv = rv.Elem()
+	}
+	if rv.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("structtag: want a struct or pointer to struct, got %s", rv.Kind())
+	}
+
+	t := rv.Type()
+	groups := make(map[string][]string)
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if !f.IsExported() {
+			continue
+		}
+		value, ok := f.Tag.Lookup(tag)
+		if !ok || value == "-" {
+			continue
+		}
+		groups[value] = append(groups[value], f.Name)
+	}
+	return groups, nil
+}

--- a/internal/structtag/structtag_test.go
+++ b/internal/structtag/structtag_test.go
@@ -1,0 +1,99 @@
+package structtag
+
+import (
+	"reflect"
+	"testing"
+)
+
+// sample mirrors the original playground domain: a struct annotated with a
+// `validate` tag across required / optional / association fields.
+type sample struct {
+	Address          *string  `validate:"required"`
+	NetworkID        *uint    `validate:"required"`
+	NodeID           *uint    `validate:"optional"`
+	PoolID           *uint    `validate:"optional"`
+	ToTransactions   []string `validate:"optional,association"`
+	FromTransactions []string `validate:"optional,association"`
+	Untagged         string
+	Skipped          string `validate:"-"`
+	//lint:ignore U1000 read via reflection to verify unexported fields are skipped
+	unexported string `validate:"required"`
+}
+
+func TestGroupFieldsByTag(t *testing.T) {
+	want := map[string][]string{
+		"required":             {"Address", "NetworkID"},
+		"optional":             {"NodeID", "PoolID"},
+		"optional,association": {"ToTransactions", "FromTransactions"},
+	}
+
+	t.Run("by value", func(t *testing.T) {
+		got, err := GroupFieldsByTag(sample{}, "validate")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("groups = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("by pointer", func(t *testing.T) {
+		got, err := GroupFieldsByTag(&sample{}, "validate")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("groups = %v, want %v", got, want)
+		}
+	})
+}
+
+func TestGroupFieldsByTag_DeclarationOrderPreserved(t *testing.T) {
+	type ordered struct {
+		C string `g:"x"`
+		A string `g:"x"`
+		B string `g:"x"`
+	}
+	got, err := GroupFieldsByTag(ordered{}, "g")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"C", "A", "B"} // field order, not alphabetical
+	if !reflect.DeepEqual(got["x"], want) {
+		t.Errorf("order = %v, want %v", got["x"], want)
+	}
+}
+
+func TestGroupFieldsByTag_NoMatches(t *testing.T) {
+	type none struct {
+		A string `validate:"required"`
+	}
+	got, err := GroupFieldsByTag(none{}, "missing")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("groups = %v, want empty", got)
+	}
+}
+
+func TestGroupFieldsByTag_Errors(t *testing.T) {
+	var nilPtr *sample
+	tests := []struct {
+		name string
+		in   any
+	}{
+		{"untyped nil", nil},
+		{"non-struct", 42},
+		{"string", "nope"},
+		{"slice", []int{1, 2}},
+		{"nil pointer", nilPtr},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := GroupFieldsByTag(tt.in, "validate"); err == nil {
+				t.Errorf("GroupFieldsByTag(%#v) = nil error, want error", tt.in)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1,149 +1,16 @@
+// Command gotest is a small Cobra-based CLI playground and proof-of-concept.
 package main
 
-import (
-	"fmt"
-	"log"
-	"os"
-	"reflect"
-	"sort"
-	"time"
+import "github.com/AndriyKalashnykov/gotest/internal/cmd"
 
-	"github.com/AndriyKalashnykov/gotest/internal/calc"
-	"github.com/AndriyKalashnykov/gotest/internal/cmd"
-	"github.com/worldline-go/struct2"
-)
-
+// Version is the release version of gotest.
+//
+// `make release` greps the declaration line below to create the git tag, so
+// keep it a single line whose value is a double-quoted semver (vX.Y.Z). It also
+// seeds the version reported by the `version` command for non-release builds;
+// goreleaser overrides that via -ldflags (-X main.version=...) at release time.
 const Version = "v0.0.14"
 
-func SortPrint(m map[string]interface{}) {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-
-	for _, k := range keys {
-		fmt.Printf("Key:%v Type: %T, Value: %v\n", k, m[k], m[k])
-	}
-}
-
-type Transaction struct {
-	Name *string `validate:"required"`
-}
-
-type Account struct {
-	Address          *string       `validate:"required"`
-	NetworkID        *uint         `validate:"required"`
-	NodeID           *uint         `validate:"optional"`
-	PoolID           *uint         `validate:"optional"`
-	ToTransactions   []Transaction `validate:"optional,association"`
-	FromTransactions []Transaction `validate:"optional,association"`
-}
-
-type FieldsByTag struct {
-	TagName              string
-	Required             []string
-	Optional             []string
-	OptionalAssociations []string
-}
-
-var AccountTaggedFields = make(map[string]*FieldsByTag)
-
-const tagNameValidate = "validate"
-
-func parseStruct(tagName string, v reflect.Value, tag reflect.StructTag, fn func(string, reflect.Value, reflect.StructTag), tf map[string]*FieldsByTag) {
-	v = reflect.Indirect(v)
-
-	switch v.Kind() {
-	case reflect.Struct:
-		t := v.Type()
-		for i := 0; i < t.NumField(); i++ {
-			switch t.Field(i).Tag.Get(tagName) {
-			case "required":
-				tf[tagName].Required = append(tf[tagName].Required, t.Field(i).Name)
-			case "optional":
-				tf[tagName].Optional = append(tf[tagName].Optional, t.Field(i).Name)
-			case "optional,association":
-				tf[tagName].OptionalAssociations = append(tf[tagName].OptionalAssociations, t.Field(i).Name)
-			}
-			//fmt.Println("field: ", t.Field(i).Name, ", tag value: ", t.Field(i).Tag.Get("validate"))
-			parseStruct(tagName, v.Field(i), t.Field(i).Tag, fn, tf)
-		}
-	case reflect.Slice, reflect.Array:
-		if v.Type().Elem().Kind() == reflect.String {
-			for i := 0; i < v.Len(); i++ {
-				parseStruct(tagName, v.Index(i), tag, fn, tf)
-			}
-		}
-	case reflect.String:
-		fn(tagName, v, tag)
-	}
-}
-
-func translate(tagName string, v reflect.Value, tag reflect.StructTag) {
-	if !v.CanSet() {
-		// unexported fields cannot be set
-		//fmt.Printf("Skipping %q %s because it cannot be set.\n", v.String(), tag)
-		return
-	}
-	val := tag.Get(tagNameValidate)
-	if val == "" {
-		return
-	}
-	// modify values if needed
-	//v.SetString(fmt.Sprintf("value %q translated with %s", v.String(), val))
-}
-
 func main() {
-
 	cmd.Execute()
-	//fmt.Println("Version:\t", Version)
-
-	if 2 == 1 {
-		log.Println("Hello : ", os.Getenv("USER"))
-		calcRest := calc.Add(4, 6)
-		log.Println("add: ", calcRest)
-
-		type ColorGroup struct {
-			ID     int       `json:"id"`
-			Name   string    `json:"name"`
-			Colors []string  `json:"colors"`
-			Date   time.Time `json:"time"`
-		}
-
-		d, _ := time.Parse(time.RFC3339, "2006-01-02T15:04:05Z")
-
-		group := ColorGroup{
-			ID:     1,
-			Name:   "Reds",
-			Colors: []string{"Crimson", "Red", "Ruby", "Maroon"},
-			Date:   d,
-		}
-
-		result := (&struct2.Decoder{}).SetTagName("json").Map(group) // default tag name is "struct"
-
-		fmt.Printf("%#v", result)
-		SortPrint(result)
-	}
-
-	AccountTaggedFields[tagNameValidate] = &FieldsByTag{TagName: tagNameValidate, Required: []string{}, Optional: []string{}, OptionalAssociations: []string{}}
-
-	address := "1345345623452345"
-	networkID := uint(1)
-	nodeId := uint(1)
-	poolId := uint(1)
-	tr1 := "Tr1"
-	structObj := Account{
-		Address:   &address,
-		NetworkID: &networkID,
-		NodeID:    &nodeId,
-		PoolID:    &poolId,
-		ToTransactions: []Transaction{{
-			Name: &tr1,
-		}},
-	}
-	parseStruct(tagNameValidate, reflect.ValueOf(&structObj), "", translate, AccountTaggedFields)
-	//fmt.Printf("%#v\n", v)
-
-	fmt.Printf("%#v\\n", AccountTaggedFields[tagNameValidate])
 }

--- a/version.go
+++ b/version.go
@@ -9,8 +9,10 @@ import (
 )
 
 var (
-	shortened  = false
-	version    = "local-dev"
+	shortened = false
+	// version/commit/date are overridden at build time via -ldflags
+	// (-X main.version=... etc.). version defaults to the release constant.
+	version    = Version
 	commit     = "none"
 	date       = "unknown"
 	output     = "json"


### PR DESCRIPTION
## Intent vs. actual (before)
The repo is a Cobra CLI POC meant to (a) report version and (b) demonstrate reflection-based struct-tag grouping. But the demo ran **unconditionally inside `main()`**, so `gotest version` printed version JSON *plus* a struct dump. `main.go` also carried dead code (`if 2 == 1`), a no-op `translate` callback, a `%#v\n` literal-backslash bug, and incomplete slice recursion. `calc` had a pointless `test()` "tested" by a no-op `TestTest`. `root.go` had a dead `--toggle` flag.

## Changes
- **`internal/structtag`** (new) — `GroupFieldsByTag(v, tag)` groups a struct's exported field names by a tag value via reflection; handles pointers / nil / non-struct, skips unexported and `-` tags. Comprehensive table-driven + edge-case tests, **100% coverage**.
- **`internal/cmd/fields.go`** (new) — `gotest fields` exposes the demo **on demand** (JSON output, `--tag` flag) instead of as a `main()` side effect. Integration test covers it.
- **`internal/calc`** — dropped `test()`; added `Multiply` and `Divide` (`ErrDivideByZero`); replaced the no-op test with table-driven tests, **100% coverage**.
- **`internal/cmd/root.go`** — dropped the dead `--toggle` flag; renamed config `.example` → `.gotest`; tidied boilerplate.
- **`main.go`** — reduced to a real entrypoint; kept the Makefile-grepped `const Version` (reworded the doc comment so the grep still resolves to a single value); `version` now defaults to it instead of `"local-dev"`.
- `go mod tidy` drops the now-unused `worldline-go/struct2` dependency.
- Docs (README Usage section, CLAUDE.md project structure) updated to match.

## Behavior (after)
- `gotest version` → clean JSON, no struct dump
- bare `gotest` → help (no side-effect dump)
- `gotest fields` / `gotest fields --tag <t>` → the demo, on demand

## Test plan
- `make ci` (static-check + test + build) passes locally; `go vet` clean.
- Coverage: `calc` 100%, `structtag` 100%, `cmd` 65% (remainder is cobra/viper glue).
- `make version` → `v0.0.14` (release grep intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)