### PR TITLE
docs(readme): rename header to "Go CLI Playground"; sync Go 1.26 + targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-brightgreen.svg)](https://opensource.org/licenses/MIT)
 [![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://app.renovatebot.com/dashboard#github/AndriyKalashnykov/gotest)
 
-# gotest — Go CLI Playground
+# Go CLI Playground
 
 A Go CLI playground and proof-of-concept built with **Cobra** (commands), **Viper** (config),
 and **GoReleaser** (release automation). It demonstrates reflection-based struct-tag parsing and
@@ -16,7 +16,7 @@ dev toolchain, a `static-check` quality gate (staticcheck + govulncheck + Trivy 
 
 | Component | Technology |
 |-----------|------------|
-| Language | Go 1.25 (see `go.mod`) |
+| Language | Go 1.26 (see `go.mod`) |
 | CLI framework | [Cobra](https://github.com/spf13/cobra) |
 | Configuration | [Viper](https://github.com/spf13/viper) |
 | Release automation | [GoReleaser](https://goreleaser.com/) |
@@ -40,7 +40,7 @@ make run       # build and run gotest
 | Tool | Version | Purpose |
 |------|---------|---------|
 | [mise](https://mise.jdx.dev/) | latest | Provisions pinned dev tools (staticcheck, govulncheck, Trivy, gitleaks, act, node) |
-| [Go](https://go.dev/dl/) | 1.25+ | Go toolchain (see `go.mod`) |
+| [Go](https://go.dev/dl/) | 1.26+ | Go toolchain (see `go.mod`) |
 | [GNU Make](https://www.gnu.org/software/make/) | 3.81+ | Build orchestration |
 | [Docker](https://www.docker.com/) | latest | Container image builds (optional) |
 
@@ -116,6 +116,7 @@ Run `make help` to see all available targets.
 | Target | Description |
 |--------|-------------|
 | `make static-check` | Run all static analysis (lint + vulncheck + secrets + trivy-fs) |
+| `make check-toolchain-alignment` | Verify the Go version matches across go.mod and .mise.toml |
 | `make lint` | Run staticcheck linter |
 | `make vulncheck` | Scan for known Go vulnerabilities (govulncheck) |
 | `make trivy-fs` | Scan filesystem dependencies and secrets for CVEs (Trivy) |

--- a/hack/generate-changelog.sh
+++ b/hack/generate-changelog.sh
@@ -8,7 +8,7 @@ PREV_VERSION=$(git describe --tags "$(git rev-list --tags --max-count=1)")
 NEW_HASH=$(git rev-parse --verify HEAD)
 
 OUTPUT=$(git log "${PREV_VERSION}..${NEW_HASH}" --no-merges \
-  --pretty=format:'* [view commit](http://github.com/AndriyKalashnykov/gotest/commit/%H) %s' --reverse)
+  --pretty=format:'* [view commit](https://github.com/AndriyKalashnykov/gotest/commit/%H) %s' --reverse)
 
 {
   echo "<!-- START ${NEXT_TAG} -->"

--- a/hack/get-gotest.sh
+++ b/hack/get-gotest.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 
 OWNER=AndriyKalashnykov
 PROJECT=gotest
-BIN_DIR=/usr/local/bin
+BIN_DIR="${BIN_DIR:-/usr/local/bin}"   # override install location: BIN_DIR=~/bin ./get-gotest.sh
 
 VERSION_TO_INSTALL=${1:-}
 


### PR DESCRIPTION
- **README H1** → `# Go CLI Playground` (aligned with the refreshed GitHub About one-liner, set via `/repo-about`).
- **/readme review fixes** (self-review guard active): `Go 1.25 → 1.26` in Tech Stack + Prerequisites (go.mod is `1.26.4` since the toolchain PR), and added the missing **`check-toolchain-alignment`** target to the Make Targets table.
- **Hardcoded-value audit** — no operator-tunable host/port/timeout hardcodes (this CLI has no network surface; the only literals are intrinsic project URLs + informational links). Two small genuine improvements: made the installer's `BIN_DIR` env-overridable (`${BIN_DIR:-/usr/local/bin}`), and `generate-changelog.sh` commit URL `http → https`.

Docs/scripts only — CI `code` paths-filter skips the heavy jobs; `ci-pass` gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)