### PR TITLE
fix(makefile): guard release target against pre-existing tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,8 +111,16 @@ release: clean
 		echo "ERROR: VERSION '$(VERSION)' is not valid semver (expected vMAJOR.MINOR.PATCH)"; \
 		exit 1; \
 	fi
+	@if git rev-parse -q --verify "refs/tags/$(VERSION)" >/dev/null 2>&1; then \
+		echo "ERROR: tag $(VERSION) already exists locally. Pick a new version or delete it: git tag -d $(VERSION)"; \
+		exit 1; \
+	fi
+	@if git ls-remote --exit-code --tags origin "refs/tags/$(VERSION)" >/dev/null 2>&1; then \
+		echo "ERROR: tag $(VERSION) already exists on origin. Pick a new version."; \
+		exit 1; \
+	fi
 	@echo -n "Are you sure to create and push ${VERSION} tag? [y/N] " && read ans && [ $${ans:-N} = y ]
-	@git commit -a -s -m "Cut ${VERSION} release"
+	@if [ -n "$$(git status --porcelain)" ]; then git commit -a -s -m "Cut ${VERSION} release"; else echo "clean tree — tagging HEAD"; fi
 	@git tag ${VERSION}
 	@git push origin ${VERSION}
 	@git push


### PR DESCRIPTION
The `release` recipe ran `git commit -a` then `git tag ${VERSION}` with no pre-existence check. Re-running with an existing tag lands a dangling "Cut vX release" commit while `git tag` aborts — a half-published release. Also `git commit -a` exits non-zero on a clean tree, aborting a no-op-diff release before tagging.

Adds local (`git rev-parse --verify`) and remote (`git ls-remote --exit-code --tags`) tag guards before the confirm prompt, plus clean-tree tolerance so the commit step tags HEAD instead of failing on an empty diff.

Verified: `make -n release` parses; `make release VERSION=v0.0.9` (existing tag) errors at the guard before any commit/tag, tree stays clean.

Implements Safety Check #16 from the /makefile skill.